### PR TITLE
fix(openshift): delete operator webhooks before namespace cleanup on uninstall

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         echo "$gofmt_out"
     - name: golangci-lint
       if: ${{ needs.changes.outputs.non-docs == 'true' }}
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
       with:
         version: v2.7.2
         args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -79,4 +79,4 @@ jobs:
         make bin/tool
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/tektoncd/pipeline v1.12.0
 	github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2
 	github.com/tektoncd/pruner v0.4.0
-	github.com/tektoncd/triggers v0.35.0
+	github.com/tektoncd/triggers v0.36.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	golang.org/x/mod v0.36.0
@@ -164,7 +164,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/cel-go v0.28.0 // indirect
+	github.com/google/cel-go v0.28.1 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-containerregistry v0.21.5 // indirect
@@ -300,7 +300,7 @@ require (
 	google.golang.org/api v0.272.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
-	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/manifestival/client-go-client v0.6.0
 	github.com/manifestival/manifestival v0.7.2
 	github.com/markbates/inflect v1.0.4
-	github.com/openshift-pipelines/pipelines-as-code v0.46.0
+	github.com/openshift-pipelines/pipelines-as-code v0.47.0
 	github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9
 	github.com/openshift/apiserver-library-go v0.0.0-20260303173613-cd3676268d31
 	github.com/openshift/client-go v0.0.0-20260429123927-c81f86abfa6a

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cel-go v0.12.7/go.mod h1:Jk7ljRzLBhkmiAwBoUxB1sZSCVBAzkqPF25olK/iRDw=
-github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
-github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/certificate-transparency-go v1.3.2 h1:9ahSNZF2o7SYMaKaXhAumVEzXB2QaayzII9C8rv7v+A=
 github.com/google/certificate-transparency-go v1.3.2/go.mod h1:H5FpMUaGa5Ab2+KCYsxg6sELw3Flkl7pGZzWdBoYLXs=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=
@@ -1251,8 +1251,8 @@ github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2 h1:v4UPEbe6MEto5
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2/go.mod h1:BC6F3DlZc+wpUT9YcwG9MoSfb4tUiH2olB9xYoIsB4I=
 github.com/tektoncd/pruner v0.4.0 h1:DMLoiJIy28WNwPC1H6mW4PzDq1egHgl6oTAG2i8in/E=
 github.com/tektoncd/pruner v0.4.0/go.mod h1:oxmjhrMNGsovv0zz1/TbJk2/bhTBVkR0MaL+io2c9GY=
-github.com/tektoncd/triggers v0.35.0 h1:9Z5Cqn7RZTgyspWgWYFHz6AtWUUhd/awJeaisjZdF98=
-github.com/tektoncd/triggers v0.35.0/go.mod h1:te1wPij1VJ/59wqpVKfwxZHRS/FOZSCMSbBTpKtLfz4=
+github.com/tektoncd/triggers v0.36.0 h1:nyNkMN3L+TvpRHQXDIXc8hqicj494Xx9Dv2+8wgjxe8=
+github.com/tektoncd/triggers v0.36.0/go.mod h1:O3kGLFBWDgjgvlGNdGWcrV2rVoRvgousDKhTwCSeakU=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
@@ -2124,8 +2124,8 @@ google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openshift-pipelines/pipelines-as-code v0.46.0 h1:sDi3mzsKlRL0yiNKRUGM+Xl+ItVY9onKUeJC1w5MDdA=
-github.com/openshift-pipelines/pipelines-as-code v0.46.0/go.mod h1:5tKgNew3eTQjsunswAm6HPQwIg2eiUuAr+9j0/SyulM=
+github.com/openshift-pipelines/pipelines-as-code v0.47.0 h1:lioOlrpUIf4vmWHzHlInaN5In2MlDYGCDneoF9otRDE=
+github.com/openshift-pipelines/pipelines-as-code v0.47.0/go.mod h1:ITB6ecPCKXspzDlWhBG7sfx8g8ylyY3BSgBDow187Yg=
 github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9 h1:lZw6pYY7El1giNk1lYvkp6hLungiqwIOqLlH+Hm7w9g=
 github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/openshift/apiserver-library-go v0.0.0-20260303173613-cd3676268d31 h1:oYPQMrkzyk002L5aN8I2tkUHTEu9lsVrc1qiJmHJdXU=

--- a/pkg/reconciler/openshift/tektonconfig/admission_webhooks.go
+++ b/pkg/reconciler/openshift/tektonconfig/admission_webhooks.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	namespaceAdmissionWebhookName = "namespace.operator.tekton.dev"
+	proxyAdmissionWebhookName     = "proxy.operator.tekton.dev"
+)
+
+// removeOperatorAdmissionWebhooks deletes operator admission webhooks before namespace
+// label cleanup during TektonConfig finalization. This prevents finalize from failing when
+// the openshift-pipelines operand namespace (and proxy-webhook service) is already gone
+// but the webhook configurations still exist (SRVKP-12010).
+func removeOperatorAdmissionWebhooks(ctx context.Context, kubeClient kubernetes.Interface) error {
+	if err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(
+		ctx, namespaceAdmissionWebhookName, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete validating webhook %s: %w", namespaceAdmissionWebhookName, err)
+	}
+
+	if err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(
+		ctx, proxyAdmissionWebhookName, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete mutating webhook %s: %w", proxyAdmissionWebhookName, err)
+	}
+
+	return nil
+}

--- a/pkg/reconciler/openshift/tektonconfig/admission_webhooks_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/admission_webhooks_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestRemoveOperatorAdmissionWebhooks(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes namespace and proxy webhooks", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset(
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceAdmissionWebhookName},
+			},
+			&admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: proxyAdmissionWebhookName},
+			},
+		)
+
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.NilError(t, err)
+
+		_, err = kc.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, namespaceAdmissionWebhookName, metav1.GetOptions{})
+		assert.ErrorContains(t, err, "not found")
+
+		_, err = kc.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, proxyAdmissionWebhookName, metav1.GetOptions{})
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("succeeds when webhooks are already gone", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset()
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.NilError(t, err)
+	})
+
+	t.Run("returns error when delete fails", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset(
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceAdmissionWebhookName},
+			},
+		)
+		kc.PrependReactor("delete", "validatingwebhookconfigurations", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("delete failed")
+		})
+
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.ErrorContains(t, err, "failed to delete validating webhook")
+	})
+}

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -256,6 +256,10 @@ func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonC
 		}
 	}
 
+	if err := removeOperatorAdmissionWebhooks(ctx, oe.kubeClientSet); err != nil {
+		return err
+	}
+
 	r := rbac{
 		kubeClientSet: oe.kubeClientSet,
 		version:       os.Getenv(versionKey),

--- a/pkg/reconciler/openshift/tektonpruner/extension.go
+++ b/pkg/reconciler/openshift/tektonpruner/extension.go
@@ -21,32 +21,65 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	tektonPrunerWebhookDeployment = "tekton-pruner-webhook"
+	webhookContainerName          = "webhook"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
-	return openshiftExtension{}
+	return &openshiftExtension{
+		tektonConfigLister: tektonConfiginformer.Get(ctx).Lister(),
+	}
 }
 
-type openshiftExtension struct{}
+type openshiftExtension struct {
+	tektonConfigLister occommon.TektonConfigLister
+	resolvedTLSConfig  *occommon.TLSEnvVars
+}
 
-func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{
+func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	trns := []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 	}
+
+	if oe.resolvedTLSConfig != nil {
+		trns = append(trns,
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", tektonPrunerWebhookDeployment, []string{webhookContainerName}, occommon.WebhookEnvVarPrefix),
+		)
+	}
+
+	return trns
 }
-func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
-	return nil
-}
-func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
-	return nil
-}
-func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+
+func (oe *openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
+	logger := logging.FromContext(ctx)
+
+	resolvedTLS, err := occommon.ResolveCentralTLSToEnvVars(ctx, oe.tektonConfigLister)
+	if err != nil {
+		return err
+	}
+	oe.resolvedTLSConfig = resolvedTLS
+	if oe.resolvedTLSConfig != nil {
+		logger.Infof("Injecting central TLS config into pruner webhook: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
+	}
+
 	return nil
 }
 
-func (oe openshiftExtension) GetPlatformData() string {
+func (oe *openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}
+func (oe *openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}
+
+func (oe *openshiftExtension) GetPlatformData() string {
 	return ""
 }

--- a/pkg/reconciler/openshift/tektonpruner/extension_test.go
+++ b/pkg/reconciler/openshift/tektonpruner/extension_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonpruner
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func makePrunerWebhookDeployment(t *testing.T) unstructured.Unstructured {
+	t.Helper()
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tektonPrunerWebhookDeployment,
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: webhookContainerName},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert deployment to unstructured: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+	return u
+}
+
+func TestPrunerTransformers_NoTLSConfig(t *testing.T) {
+	ext := &openshiftExtension{
+		resolvedTLSConfig: nil,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonPruner{})
+
+	u := makePrunerWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != webhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
+			}
+		}
+	}
+}
+
+func TestPrunerTransformers_WithTLSConfig_InjectsEnvVarsIntoWebhook(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{
+		resolvedTLSConfig: tlsConfig,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonPruner{})
+
+	u := makePrunerWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	envMap := map[string]string{}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != webhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			envMap[e.Name] = e.Value
+		}
+	}
+
+	webhookMinVersion := occommon.WebhookEnvVarPrefix + occommon.TLSMinVersionEnvVar
+	webhookCipherSuites := occommon.WebhookEnvVarPrefix + occommon.TLSCipherSuitesEnvVar
+
+	if got := envMap[webhookMinVersion]; got != tlsConfig.MinVersion {
+		t.Errorf("%s = %q, want %q", webhookMinVersion, got, tlsConfig.MinVersion)
+	}
+	if got := envMap[webhookCipherSuites]; got != tlsConfig.CipherSuites {
+		t.Errorf("%s = %q, want %q", webhookCipherSuites, got, tlsConfig.CipherSuites)
+	}
+}
+
+func TestPrunerTransformers_WithTLSConfig_DoesNotInjectIntoOtherDeployments(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.3",
+		CipherSuites: "TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{
+		resolvedTLSConfig: tlsConfig,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonPruner{})
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tekton-pruner-controller",
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "controller"},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	result := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, result); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	for _, c := range result.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s injected into non-webhook deployment", e.Name)
+			}
+		}
+	}
+}

--- a/pkg/reconciler/shared/tektonconfig/pruner/pruner.go
+++ b/pkg/reconciler/shared/tektonconfig/pruner/pruner.go
@@ -128,6 +128,16 @@ func UpdatePruner(ctx context.Context, old *v1alpha1.TektonPruner, new *v1alpha1
 		updated = true
 	}
 
+	oldPlatformData := old.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey]
+	newPlatformData := new.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey]
+	if oldPlatformData != newPlatformData {
+		if old.ObjectMeta.Annotations == nil {
+			old.ObjectMeta.Annotations = map[string]string{}
+		}
+		old.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey] = newPlatformData
+		updated = true
+	}
+
 	if updated {
 		_, err := clients.Update(ctx, old, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -209,8 +209,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 		tc.Status.MarkComponentNotReady(msg)
 		return v1alpha1.REQUEUE_EVENT_AFTER
 	} else {
-		logger.Infof("TektonPruner is enabled.Creating TektonPipeline CR")
+		logger.Infof("TektonPruner is enabled. Creating TektonPruner CR")
 		tektonPruner := pruner.GetTektonPrunerCR(tc, r.operatorVersion)
+		if platformData := r.extension.GetPlatformData(); platformData != "" {
+			if tektonPruner.Annotations == nil {
+				tektonPruner.Annotations = map[string]string{}
+			}
+			tektonPruner.Annotations[v1alpha1.PlatformDataHashKey] = platformData
+		}
 		if _, err := pruner.EnsureTektonPrunerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPruners(), tektonPruner); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonPruner %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -67,6 +67,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
+		return err
 	}
 
 	if original.Spec.Profile == v1alpha1.ProfileLite {

--- a/vendor/github.com/google/cel-go/cel/program.go
+++ b/vendor/github.com/google/cel-go/cel/program.go
@@ -370,7 +370,7 @@ func (p *prog) ContextEval(ctx context.Context, input any) (ref.Val, *EvalDetail
 	}
 	out, det, err := p.Eval(vars)
 	if err != nil && errors.Is(err, interpreter.InterruptError{}) {
-		return out, det, context.Cause(ctx)
+		return out, det, fmt.Errorf("%w: %w", err, context.Cause(ctx))
 	}
 	return out, det, err
 }

--- a/vendor/github.com/google/cel-go/checker/cost.go
+++ b/vendor/github.com/google/cel-go/checker/cost.go
@@ -159,6 +159,11 @@ func (se SizeEstimate) Union(size SizeEstimate) SizeEstimate {
 	return result
 }
 
+// AsCost converts a size estimates to an equivalent cost estimate.
+func (se SizeEstimate) AsCost() CostEstimate {
+	return se.MultiplyByCostFactor(1)
+}
+
 // CostEstimate represents an estimated cost range and provides add and multiply operations
 // that do not overflow.
 type CostEstimate struct {

--- a/vendor/github.com/google/cel-go/common/env/BUILD.bazel
+++ b/vendor/github.com/google/cel-go/common/env/BUILD.bazel
@@ -23,12 +23,14 @@ go_library(
     name = "go_default_library",
     srcs = [
         "env.go",
+        "io.go",
     ],
     importpath = "github.com/google/cel-go/common/env",
     deps = [
         "//common:go_default_library",
         "//common/decls:go_default_library",
         "//common/types:go_default_library",
+        "@in_yaml_go_yaml_v3//:go_default_library",
     ],
 )
 
@@ -37,6 +39,7 @@ go_test(
     size = "small",
     srcs = [
         "env_test.go",
+        "io_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
@@ -45,6 +48,7 @@ go_test(
         "//common/operators:go_default_library",
         "//common/overloads:go_default_library",
         "//common/types:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@in_yaml_go_yaml_v3//:go_default_library",
     ],
 )

--- a/vendor/github.com/google/cel-go/common/env/env.go
+++ b/vendor/github.com/google/cel-go/common/env/env.go
@@ -258,7 +258,9 @@ type Variable struct {
 
 	// Type represents the type declaration for the variable.
 	//
-	// Deprecated: use the embedded *TypeDesc fields directly.
+	// When serialized, 'type' is used for shorthand specifier string.
+	//
+	// Use GetType() for getting the effective type.
 	Type *TypeDesc `yaml:"type,omitempty"`
 
 	// TypeDesc is an embedded set of fields allowing for the specification of the Variable type.
@@ -275,6 +277,9 @@ func (v *Variable) Validate() error {
 	}
 	if err := v.GetType().Validate(); err != nil {
 		return fmt.Errorf("invalid variable %q: %w", v.Name, err)
+	}
+	if v.GetType().IsTypeParam {
+		return fmt.Errorf("invalid variable %q: variables cannot be type parameters", v.Name)
 	}
 	return nil
 }
@@ -844,6 +849,34 @@ func (td *TypeDesc) Validate() error {
 	return nil
 }
 
+func formatSpecifierImpl(td *TypeDesc, sb *strings.Builder) {
+	if td.IsTypeParam {
+		sb.WriteRune('~')
+		sb.WriteString(td.TypeName)
+		return
+	}
+	sb.WriteString(td.TypeName)
+	l := len(td.Params)
+	if l < 1 {
+		return
+	}
+	sb.WriteRune('<')
+	for i, p := range td.Params {
+		formatSpecifierImpl(p, sb)
+		if i < l-1 {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteRune('>')
+}
+
+// SpecifierFormat returns the short text representation of the type. e.g. "map<string, int>"
+func (td *TypeDesc) SpecifierFormat() string {
+	var sb strings.Builder
+	formatSpecifierImpl(td, &sb)
+	return sb.String()
+}
+
 // AsCELType converts the serializable object to a *types.Type value.
 func (td *TypeDesc) AsCELType(tp types.Provider) (*types.Type, error) {
 	err := td.Validate()
@@ -853,6 +886,27 @@ func (td *TypeDesc) AsCELType(tp types.Provider) (*types.Type, error) {
 	switch td.TypeName {
 	case "dyn":
 		return types.DynType, nil
+	// short aliases for WKTs
+	case "duration":
+		return types.DurationType, nil
+	case "timestamp":
+		return types.TimestampType, nil
+	case "any":
+		return types.AnyType, nil
+	case "null", "null_type":
+		return types.NullType, nil
+	case "bool_wrapper":
+		return types.NewNullableType(types.BoolType), nil
+	case "bytes_wrapper":
+		return types.NewNullableType(types.BytesType), nil
+	case "double_wrapper":
+		return types.NewNullableType(types.DoubleType), nil
+	case "int_wrapper":
+		return types.NewNullableType(types.IntType), nil
+	case "uint_wrapper":
+		return types.NewNullableType(types.UintType), nil
+	case "string_wrapper":
+		return types.NewNullableType(types.StringType), nil
 	case "map":
 		kt, err := td.Params[0].AsCELType(tp)
 		if err != nil {
@@ -925,6 +979,15 @@ func SerializeTypeDesc(t *types.Type) *TypeDesc {
 	var params []*TypeDesc
 	for _, p := range t.Parameters() {
 		params = append(params, SerializeTypeDesc(p))
+	}
+	// Special types, these aren't useful for describing environments.
+	switch t.Kind() {
+	case types.ErrorKind:
+		typeName = "*error*"
+	case types.UnknownKind:
+		typeName = "*unknown*"
+	case types.UnspecifiedKind:
+		typeName = "*unspecified type*"
 	}
 	return NewTypeDesc(typeName, params...)
 }

--- a/vendor/github.com/google/cel-go/common/env/io.go
+++ b/vendor/github.com/google/cel-go/common/env/io.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type internalTypeDesc struct {
+	TypeName    string      `yaml:"type_name"`
+	Params      []*TypeDesc `yaml:"params,omitempty"`
+	IsTypeParam bool        `yaml:"is_type_param,omitempty"`
+}
+
+// Embedding TypeDesc in variable causes issues with customizing
+// unmarshalling / marshalling. Work around with a parallel type.
+type internalVariable struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+
+	// Type represents the type declaration for the variable.
+	Type *TypeDesc `yaml:"type,omitempty"`
+
+	TypeName    string      `yaml:"type_name"`
+	Params      []*TypeDesc `yaml:"params,omitempty"`
+	IsTypeParam bool        `yaml:"is_type_param,omitempty"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshal
+func (v *Variable) UnmarshalYAML(n *yaml.Node) error {
+	buf := internalVariable{}
+	err := n.Decode(&buf)
+	if err != nil {
+		return err
+	}
+	v.Name = buf.Name
+	v.Description = buf.Description
+	if buf.TypeName != "" {
+		v.TypeDesc = &TypeDesc{
+			TypeName:    buf.TypeName,
+			Params:      buf.Params,
+			IsTypeParam: buf.IsTypeParam,
+		}
+	} else if buf.Type != nil {
+		v.TypeDesc = buf.Type
+	}
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler
+func (v *Variable) MarshalYAML() (any, error) {
+	// The presence of an unmarshaller alters the default marshaller behavior so
+	// provide a simple marshal implementation.
+	buf := internalVariable{
+		Name:        v.Name,
+		Description: v.Description,
+	}
+	if t := v.GetType(); t != nil {
+		buf.TypeName = t.TypeName
+		buf.Params = t.Params
+		buf.IsTypeParam = t.IsTypeParam
+	}
+	return &buf, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler
+func (td *TypeDesc) UnmarshalYAML(n *yaml.Node) error {
+	if td == nil {
+		return fmt.Errorf("unexpected Unmarshal for TypeDesc at: %d", n.Line)
+	}
+	if n.Kind == yaml.ScalarNode {
+		o, err := ParseTypeDesc(n.Value)
+		if err != nil {
+			return err
+		}
+		*td = *o
+		return nil
+	}
+
+	if n.Kind != yaml.MappingNode {
+		return errors.New("unsupported yaml for TypeDesc")
+	}
+
+	buf := internalTypeDesc{}
+	err := n.Decode(&buf)
+	if err != nil {
+		return err
+	}
+	td.TypeName = buf.TypeName
+	td.Params = buf.Params
+	td.IsTypeParam = buf.IsTypeParam
+	return nil
+}
+
+type typeDescParser struct {
+	text   string
+	pos    int
+	length int
+}
+
+// ParseTypeDesc parses a TypeDesc from the type specifier format: "map<string, int>"
+func ParseTypeDesc(text string) (*TypeDesc, error) {
+	p := &typeDescParser{text: text, length: len(text)}
+	res, err := p.parseTypeElem()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse type %q: %v", text, err)
+	}
+	p.skipWhitespace()
+	if p.pos < p.length {
+		return nil, fmt.Errorf("unexpected character %q at position %d in %q", p.text[p.pos], p.pos, text)
+	}
+	return res, nil
+}
+
+func (p *typeDescParser) parseConcreteType() (*TypeDesc, error) {
+	id, err := p.parseNamespaceIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if p.pos < p.length && p.text[p.pos] == '<' {
+		p.pos++ // consume '<'
+		var params []*TypeDesc
+		for {
+			p.skipWhitespace()
+			param, err := p.parseTypeElem()
+			if err != nil {
+				return nil, err
+			}
+			params = append(params, param)
+			p.skipWhitespace()
+			if p.pos < p.length && p.text[p.pos] == ',' {
+				p.pos++ // consume ','
+				continue
+			}
+			if p.pos < p.length && p.text[p.pos] == '>' {
+				p.pos++ // consume '>'
+				break
+			}
+			return nil, fmt.Errorf("expected ',' or '>' at position %d", p.pos)
+		}
+		return NewTypeDesc(id, params...), nil
+	}
+	return NewTypeDesc(id), nil
+}
+
+func (p *typeDescParser) parseTypeElem() (*TypeDesc, error) {
+	p.skipWhitespace()
+	if p.pos < p.length && p.text[p.pos] == '~' {
+		p.pos++ // consume '~'
+		id, err := p.parseTypeParamIdent()
+		if err != nil {
+			return nil, err
+		}
+		return NewTypeParam(id), nil
+	}
+	return p.parseConcreteType()
+}
+
+func (p *typeDescParser) parseNamespaceIdentifier() (string, error) {
+	p.skipWhitespace()
+	var id string
+	for p.pos < p.length && p.text[p.pos] != '<' {
+		c := p.text[p.pos]
+		if c == '.' {
+			id += "."
+			p.pos++ // consume '.'
+		}
+		ident, err := p.parseIdentifier()
+		if err != nil {
+			return "", err
+		}
+		id += ident
+		p.skipWhitespace()
+		if p.pos < p.length && p.text[p.pos] != '.' {
+			break
+		}
+	}
+	if id == "" {
+		return "", fmt.Errorf("missing identifier at position %d", p.pos)
+	}
+	return id, nil
+}
+
+func (p *typeDescParser) parseIdentifier() (string, error) {
+	p.skipWhitespace()
+	if p.pos >= p.length {
+		return "", fmt.Errorf("unexpected end of input")
+	}
+	start := p.pos
+	c := p.text[p.pos]
+	if !isAlpha(c) && c != '_' {
+		return "", fmt.Errorf("identifier is expected, but %q was found at position %d", c, p.pos)
+	}
+	p.pos++
+	for p.pos < p.length {
+		c := p.text[p.pos]
+		if !isAlphaNumeric(c) && c != '_' {
+			break
+		}
+		p.pos++
+	}
+	return p.text[start:p.pos], nil
+}
+
+func (p *typeDescParser) parseTypeParamIdent() (string, error) {
+	p.skipWhitespace()
+	if p.pos >= p.length {
+		return "", fmt.Errorf("unexpected end of input")
+	}
+	c := p.text[p.pos]
+	if !isAlpha(c) {
+		return "", fmt.Errorf("invalid type parameter identifier %q at position %d, must be a single character from A-Z", c, p.pos)
+	}
+	p.pos++
+	if p.pos < p.length && isAlpha(p.text[p.pos]) {
+		return "", fmt.Errorf("invalid type param, must have a single alphabetic character at position %d", p.pos)
+	}
+	return string(c), nil
+}
+
+func (p *typeDescParser) skipWhitespace() {
+	for p.pos < p.length && p.text[p.pos] == ' ' {
+		p.pos++
+	}
+}
+
+func isAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isAlphaNumeric(c byte) bool {
+	return isAlpha(c) || (c >= '0' && c <= '9')
+}
+
+// ConfigFromYAML returns a config from YAML source.
+//
+// Adds custom parsing logic for normalizing shorthand for specifiying some fields
+// in a YAML document (mainly the type-specifier shorthand).
+//
+// Using yaml.Unmarshal with any implementation should be sufficient for most
+// cases.
+func ConfigFromYAML(data []byte) (*Config, error) {
+	c := &Config{}
+	e := yaml.Unmarshal(data, c)
+	if e != nil {
+		return nil, e
+	}
+	return c, nil
+}
+
+// ConfigToYAML returns the config serialized to YAML
+//
+// Provided as a convenience wrapper around a tested YAML Marshaler.
+func ConfigToYAML(c *Config) ([]byte, error) {
+	return yaml.Marshal(c)
+}

--- a/vendor/github.com/google/cel-go/common/overloads/overloads.go
+++ b/vendor/github.com/google/cel-go/common/overloads/overloads.go
@@ -291,7 +291,6 @@ const (
 const (
 	DurationToDuration = "duration_to_duration"
 	StringToDuration   = "string_to_duration"
-	IntToDuration      = "int64_to_duration"
 )
 
 // Convert to dyn

--- a/vendor/github.com/google/cel-go/common/stdlib/standard.go
+++ b/vendor/github.com/google/cel-go/common/stdlib/standard.go
@@ -605,8 +605,6 @@ func init() {
 			decls.Overload(overloads.DurationToDuration, argTypes(types.DurationType), types.DurationType,
 				decls.OverloadExamples(`duration(duration('1s')) // duration('1s')`),
 				decls.UnaryBinding(identity)),
-			decls.Overload(overloads.IntToDuration, argTypes(types.IntType), types.DurationType,
-				decls.UnaryBinding(convertToType(types.DurationType))),
 			decls.Overload(overloads.StringToDuration, argTypes(types.StringType), types.DurationType,
 				decls.OverloadExamples(`duration('1h2m3s') // duration('3723s')`),
 				decls.UnaryBinding(convertToType(types.DurationType)))),

--- a/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/openapi_generated.go
+++ b/vendor/github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1/openapi_generated.go
@@ -1441,7 +1441,8 @@ func schema_pkg_apis_triggers_v1beta1_TriggerSpecBinding(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EventListenerBinding refers to a particular TriggerBinding or ClusterTriggerBinding resource.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1488,7 +1489,8 @@ func schema_pkg_apis_triggers_v1beta1_TriggerSpecTemplate(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EventListenerTemplate refers to a particular TriggerTemplate resource.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"ref": {
 						SchemaProps: spec.SchemaProps{

--- a/vendor/google.golang.org/grpc/clientconn.go
+++ b/vendor/google.golang.org/grpc/clientconn.go
@@ -24,10 +24,12 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -1268,8 +1270,9 @@ type addrConn struct {
 
 	channelz *channelz.SubChannel
 
-	localityLabel       string
-	backendServiceLabel string
+	localityLabel        string
+	backendServiceLabel  string
+	disconnectErrorLabel string
 }
 
 // Note: this requires a lock on ac.mu.
@@ -1286,9 +1289,14 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State, lastErr error)
 	// TODO: https://github.com/grpc/grpc-go/issues/7862 - Remove the second
 	// part of the if condition below once the issue is fixed.
 	if ac.state == connectivity.Ready || (ac.state == connectivity.Connecting && s == connectivity.Idle) {
-		disconnectionsMetric.Record(ac.cc.metricsRecorderList, 1, ac.cc.target, ac.backendServiceLabel, ac.localityLabel, "unknown")
+		disconnectError := ac.disconnectErrorLabel
+		if disconnectError == "" {
+			disconnectError = "unknown"
+		}
+		disconnectionsMetric.Record(ac.cc.metricsRecorderList, 1, ac.cc.target, ac.backendServiceLabel, ac.localityLabel, disconnectError)
 		openConnectionsMetric.Record(ac.cc.metricsRecorderList, -1, ac.cc.target, ac.backendServiceLabel, ac.securityLevelLocked(), ac.localityLabel)
 	}
+	ac.disconnectErrorLabel = "" // Reset for next time
 	ac.state = s
 	ac.channelz.ChannelMetrics.State.Store(&s)
 	if lastErr == nil {
@@ -1483,11 +1491,11 @@ func (ac *addrConn) createTransport(ctx context.Context, addr resolver.Address, 
 	addr.ServerName = ac.cc.getServerName(addr)
 	hctx, hcancel := context.WithCancel(ctx)
 
-	onClose := func(r transport.GoAwayReason) {
+	onClose := func(info transport.GoAwayInfo) {
 		ac.mu.Lock()
 		defer ac.mu.Unlock()
 		// adjust params based on GoAwayReason
-		ac.adjustParams(r)
+		ac.adjustParams(info.Reason)
 		if ctx.Err() != nil {
 			// Already shut down or connection attempt canceled.  tearDown() or
 			// updateAddrs() already cleared the transport and canceled hctx
@@ -1504,6 +1512,7 @@ func (ac *addrConn) createTransport(ctx context.Context, addr resolver.Address, 
 			return
 		}
 		ac.transport = nil
+		ac.disconnectErrorLabel = disconnectErrorString(info)
 		// Refresh the name resolver on any connection loss.
 		ac.cc.resolveNow(resolver.ResolveNowOptions{})
 		// Always go idle and wait for the LB policy to initiate a new
@@ -1558,6 +1567,32 @@ func (ac *addrConn) createTransport(ctx context.Context, addr resolver.Address, 
 	ac.transport = newTr
 	ac.startHealthCheck(hctx) // Will set state to READY if appropriate.
 	return nil
+}
+
+// disconnectErrorString returns the grpc.disconnect_error metric label corresponding
+// to the provided transport.GoAwayInfo, as specified by gRFC A94:
+// https://github.com/grpc/proposal/blob/master/A94-grpc-subchannel-disconnections-metrics.md
+func disconnectErrorString(info transport.GoAwayInfo) string {
+	err := info.Err
+	var sysErr syscall.Errno
+	switch {
+	case info.Reason != transport.GoAwayInvalid:
+		return fmt.Sprintf("GOAWAY %s", info.GoAwayCode.String())
+	case err == nil:
+		return "unknown"
+	case errors.Is(err, context.Canceled):
+		return "subchannel shutdown"
+	case errors.Is(err, syscall.ECONNRESET):
+		return "connection reset"
+	case errors.Is(err, syscall.ETIMEDOUT), errors.Is(err, context.DeadlineExceeded), errors.Is(err, os.ErrDeadlineExceeded):
+		return "connection timed out"
+	case errors.Is(err, syscall.ECONNABORTED):
+		return "connection aborted"
+	case errors.As(err, &sysErr):
+		return "socket error"
+	default:
+		return "unknown"
+	}
 }
 
 // startHealthCheck starts the health checking stream (RPC) to watch the health
@@ -1663,6 +1698,9 @@ func (ac *addrConn) tearDown(err error) {
 	}
 	curTr := ac.transport
 	ac.transport = nil
+	if ac.disconnectErrorLabel == "" {
+		ac.disconnectErrorLabel = "subchannel shutdown"
+	}
 	// We have to set the state to Shutdown before anything else to prevent races
 	// between setting the state and logic that waits on context cancellation / etc.
 	ac.updateConnectivityState(connectivity.Shutdown, nil)

--- a/vendor/google.golang.org/grpc/experimental/stats/metrics.go
+++ b/vendor/google.golang.org/grpc/experimental/stats/metrics.go
@@ -20,9 +20,26 @@
 package stats
 
 import (
+	"context"
+
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/stats"
 )
+
+type customLabelKey struct{}
+
+// NewContextWithCustomLabel returns a new context with the provided custom label
+// attached. The label will be propagated to all metric instruments specified in gRFC A108.
+func NewContextWithCustomLabel(ctx context.Context, label string) context.Context {
+	return context.WithValue(ctx, customLabelKey{}, label)
+}
+
+// CustomLabelFromContext returns the custom label from the context if it exists.
+// If the custom label is not present, it returns an empty string.
+func CustomLabelFromContext(ctx context.Context) string {
+	label, _ := ctx.Value(customLabelKey{}).(string)
+	return label
+}
 
 // MetricsRecorder records on metrics derived from metric registry.
 // Implementors must embed UnimplementedMetricsRecorder.

--- a/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
+++ b/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
@@ -126,6 +126,16 @@ var (
 	// enabled by setting the env variable
 	// GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE to true.
 	EnablePriorityLBChildPolicyCache = boolFromEnv("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE", false)
+
+	// EnableHTTPFramerReadBufferPooling enables the use of the
+	// readyreader.Reader interface to perform non-memory-pinning reads,
+	// provided the underlying net.Conn supports it. This reduces memory usage
+	// when subchannels are idle.
+	//
+	// This environment variable serves as an escape hatch to disable the
+	// feature if unforeseen issues arise, and it will be removed in a future
+	// release.
+	EnableHTTPFramerReadBufferPooling = boolFromEnv("GRPC_GO_EXPERIMENTAL_HTTP_FRAMER_READ_BUFFER_POOLING", true)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/vendor/google.golang.org/grpc/internal/envconfig/xds.go
+++ b/vendor/google.golang.org/grpc/internal/envconfig/xds.go
@@ -79,4 +79,14 @@ var (
 	// xDS bootstrap configuration via the `call_creds` field. For more details,
 	// see: https://github.com/grpc/proposal/blob/master/A97-xds-jwt-call-creds.md
 	XDSBootstrapCallCredsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_BOOTSTRAP_CALL_CREDS", false)
+
+	// XDSSNIEnabled controls if gRPC should send SNI information in xDS
+	// configured TLS handshakes. For more details, see:
+	// https://github.com/grpc/proposal/blob/master/A101-SNI-setting-and-SNI-SAN-validation.md
+	XDSSNIEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_SNI", false)
+
+	// XDSORCAToLRSPropEnabled controls whether ORCA metrics are explicitly
+	// filtered and prefix-propagated to the LRS server. For more details, see:
+	// https://github.com/grpc/proposal/blob/master/A85-lrs-custom-metrics-changes.md
+	XDSORCAToLRSPropEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION", false)
 )

--- a/vendor/google.golang.org/grpc/internal/mem/buffer_pool.go
+++ b/vendor/google.golang.org/grpc/internal/mem/buffer_pool.go
@@ -73,7 +73,7 @@ type BinaryTieredBufferPool struct {
 func NewBinaryTieredBufferPool(powerOfTwoExponents ...uint8) (*BinaryTieredBufferPool, error) {
 	return newBinaryTiered(func(size int) bufferPool {
 		return newSizedBufferPool(size, true)
-	}, &simpleBufferPool{shouldZero: true}, powerOfTwoExponents...)
+	}, &SimpleBufferPool{shouldZero: true}, powerOfTwoExponents...)
 }
 
 // NewDirtyBinaryTieredBufferPool returns a BufferPool backed by multiple
@@ -82,7 +82,7 @@ func NewBinaryTieredBufferPool(powerOfTwoExponents ...uint8) (*BinaryTieredBuffe
 func NewDirtyBinaryTieredBufferPool(powerOfTwoExponents ...uint8) (*BinaryTieredBufferPool, error) {
 	return newBinaryTiered(func(size int) bufferPool {
 		return newSizedBufferPool(size, false)
-	}, &simpleBufferPool{shouldZero: false}, powerOfTwoExponents...)
+	}, NewDirtySimplePool(), powerOfTwoExponents...)
 }
 
 func newBinaryTiered(sizedPoolFactory func(int) bufferPool, fallbackPool bufferPool, powerOfTwoExponents ...uint8) (*BinaryTieredBufferPool, error) {
@@ -258,7 +258,7 @@ func newSizedBufferPool(size int, zero bool) *sizedBufferPool {
 // buffer pools for different sizes of buffers.
 type TieredBufferPool struct {
 	sizedPools   []*sizedBufferPool
-	fallbackPool simpleBufferPool
+	fallbackPool SimpleBufferPool
 }
 
 // NewTieredBufferPool returns a BufferPool implementation that uses multiple
@@ -271,7 +271,7 @@ func NewTieredBufferPool(poolSizes ...int) *TieredBufferPool {
 	}
 	return &TieredBufferPool{
 		sizedPools:   pools,
-		fallbackPool: simpleBufferPool{shouldZero: true},
+		fallbackPool: SimpleBufferPool{shouldZero: true},
 	}
 }
 
@@ -297,16 +297,26 @@ func (p *TieredBufferPool) getPool(size int) bufferPool {
 	return p.sizedPools[poolIdx]
 }
 
-// simpleBufferPool is an implementation of the BufferPool interface that
+// SimpleBufferPool is an implementation of the mem.BufferPool interface that
 // attempts to pool buffers with a sync.Pool. When Get is invoked, it tries to
 // acquire a buffer from the pool but if that buffer is too small, it returns it
 // to the pool and creates a new one.
-type simpleBufferPool struct {
+type SimpleBufferPool struct {
 	pool       sync.Pool
 	shouldZero bool
 }
 
-func (p *simpleBufferPool) Get(size int) *[]byte {
+// NewDirtySimplePool constructs a [SimpleBufferPool]. It does not initialize
+// the buffers before returning them. Callers must ensure they don't read the
+// buffers before writing data to them.
+func NewDirtySimplePool() *SimpleBufferPool {
+	return &SimpleBufferPool{
+		shouldZero: false,
+	}
+}
+
+// Get returns a buffer with specified length from the pool.
+func (p *SimpleBufferPool) Get(size int) *[]byte {
 	bs, ok := p.pool.Get().(*[]byte)
 	if ok && cap(*bs) >= size {
 		if p.shouldZero {
@@ -333,6 +343,7 @@ func (p *simpleBufferPool) Get(size int) *[]byte {
 	return &b
 }
 
-func (p *simpleBufferPool) Put(buf *[]byte) {
+// Put returns a buffer to the pool.
+func (p *SimpleBufferPool) Put(buf *[]byte) {
 	p.pool.Put(buf)
 }

--- a/vendor/google.golang.org/grpc/internal/resolver/config_selector.go
+++ b/vendor/google.golang.org/grpc/internal/resolver/config_selector.go
@@ -115,6 +115,9 @@ type ClientInterceptor interface {
 	// ClientStream after done is called, since the interceptor is invoked by
 	// application-layer operations.  done must never be nil when called.
 	NewStream(ctx context.Context, ri RPCInfo, done func(), newStream func(ctx context.Context, done func()) (ClientStream, error)) (ClientStream, error)
+	// Close closes the interceptor. Once called, no new calls to NewStream are
+	// accepted. Ongoing calls to NewStream are allowed to complete.
+	Close()
 }
 
 // ServerInterceptor is an interceptor for incoming RPC's on gRPC server side.
@@ -123,6 +126,9 @@ type ServerInterceptor interface {
 	// information about connection RPC was received on, and HTTP Headers. This
 	// information will be piped into context.
 	AllowRPC(ctx context.Context) error // TODO: Make this a real interceptor for filters such as rate limiting.
+	// Close closes the interceptor. Once called, no new calls to NewStream are
+	// accepted. Ongoing calls to NewStream are allowed to complete.
+	Close()
 }
 
 type csKeyType string

--- a/vendor/google.golang.org/grpc/internal/transport/http2_client.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_client.go
@@ -134,6 +134,8 @@ type http2Client struct {
 	// goAwayDebugMessage contains a detailed human readable string about a
 	// GoAway frame, useful for error messages.
 	goAwayDebugMessage string
+	// goAwayCode records the http2.ErrCode received with the GoAway frame.
+	goAwayCode http2.ErrCode
 	// A condition variable used to signal when the keepalive goroutine should
 	// go dormant. The condition for dormancy is based on the number of active
 	// streams and the `PermitWithoutStream` keepalive client parameter. And
@@ -147,7 +149,7 @@ type http2Client struct {
 
 	channelz *channelz.Socket
 
-	onClose func(GoAwayReason)
+	onClose OnCloseFunc
 
 	bufferPool mem.BufferPool
 
@@ -204,7 +206,7 @@ func isTemporary(err error) bool {
 // NewHTTP2Client constructs a connected ClientTransport to addr based on HTTP2
 // and starts to receive messages on it. Non-nil error returns if construction
 // fails.
-func NewHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts ConnectOptions, onClose func(GoAwayReason)) (_ ClientTransport, err error) {
+func NewHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts ConnectOptions, onClose OnCloseFunc) (_ ClientTransport, err error) {
 	scheme := "http"
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -1015,7 +1017,7 @@ func (t *http2Client) Close(err error) {
 	// Call t.onClose ASAP to prevent the client from attempting to create new
 	// streams.
 	if t.state != draining {
-		t.onClose(GoAwayInvalid)
+		t.onClose(GoAwayInfo{Reason: GoAwayInvalid, GoAwayCode: http2.ErrCodeNo, Err: err})
 	}
 	t.state = closing
 	streams := t.activeStreams
@@ -1086,7 +1088,7 @@ func (t *http2Client) GracefulClose() {
 	if t.logger.V(logLevel) {
 		t.logger.Infof("GracefulClose called")
 	}
-	t.onClose(GoAwayInvalid)
+	t.onClose(GoAwayInfo{Reason: GoAwayInvalid, GoAwayCode: http2.ErrCodeNo})
 	t.state = draining
 	active := len(t.activeStreams)
 	t.mu.Unlock()
@@ -1236,7 +1238,10 @@ func (t *http2Client) handleData(f *parsedDataFrame) {
 	// The server has closed the stream without sending trailers.  Record that
 	// the read direction is closed, and set the status appropriately.
 	if f.StreamEnded() {
-		t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.New(codes.Internal, "server closed the stream without sending trailers"), nil, true)
+		// If client received END_STREAM from server while stream was still
+		// active, send RST_STREAM.
+		rstStream := s.getState() == streamActive
+		t.closeStream(s, io.EOF, rstStream, http2.ErrCodeNo, status.New(codes.Internal, "server closed the stream without sending trailers"), nil, true)
 	}
 }
 
@@ -1372,7 +1377,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) error {
 		// draining, to allow the client to stop attempting to create streams
 		// before disallowing new streams on this connection.
 		if t.state != draining {
-			t.onClose(t.goAwayReason)
+			t.onClose(GoAwayInfo{Reason: t.goAwayReason, GoAwayCode: t.goAwayCode})
 			t.state = draining
 		}
 	}
@@ -1422,6 +1427,7 @@ func (t *http2Client) setGoAwayReason(f *http2.GoAwayFrame) {
 	} else {
 		t.goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %q", f.ErrCode, string(f.DebugData()))
 	}
+	t.goAwayCode = f.ErrCode
 }
 
 func (t *http2Client) GetGoAwayReason() (GoAwayReason, string) {

--- a/vendor/google.golang.org/grpc/internal/transport/http_util.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http_util.go
@@ -36,6 +36,9 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/envconfig"
+	imem "google.golang.org/grpc/internal/mem"
+	"google.golang.org/grpc/internal/transport/readyreader"
 	"google.golang.org/grpc/mem"
 )
 
@@ -296,7 +299,7 @@ func decodeGrpcMessageUnchecked(msg string) string {
 }
 
 type bufWriter struct {
-	pool      *sync.Pool
+	pool      *imem.SimpleBufferPool
 	buf       []byte
 	offset    int
 	batchSize int
@@ -304,7 +307,7 @@ type bufWriter struct {
 	err       error
 }
 
-func newBufWriter(conn io.Writer, batchSize int, pool *sync.Pool) *bufWriter {
+func newBufWriter(conn io.Writer, batchSize int, pool *imem.SimpleBufferPool) *bufWriter {
 	w := &bufWriter{
 		batchSize: batchSize,
 		conn:      conn,
@@ -326,7 +329,7 @@ func (w *bufWriter) Write(b []byte) (int, error) {
 		return n, toIOError(err)
 	}
 	if w.buf == nil {
-		b := w.pool.Get().(*[]byte)
+		b := w.pool.Get(w.batchSize)
 		w.buf = *b
 	}
 	written := 0
@@ -407,22 +410,32 @@ type framer struct {
 	errDetail error
 }
 
-var writeBufferPoolMap = make(map[int]*sync.Pool)
-var writeBufferMutex sync.Mutex
+var ioBufferPoolMap = make(map[int]*imem.SimpleBufferPool)
+var ioBufferMutex sync.Mutex
+
+func bufferedReader(r io.Reader, bufSize int) io.Reader {
+	if bufSize <= 0 {
+		return r
+	}
+	if envconfig.EnableHTTPFramerReadBufferPooling {
+		if rr := readyreader.NewNonBlocking(r); rr != nil {
+			readPool := ioBufferPool(bufSize)
+			return readyreader.NewBuffered(rr, bufSize, readPool)
+		}
+	}
+	return bufio.NewReaderSize(r, bufSize)
+}
 
 func newFramer(conn io.ReadWriter, writeBufferSize, readBufferSize int, sharedWriteBuffer bool, maxHeaderListSize uint32, memPool mem.BufferPool) *framer {
 	if writeBufferSize < 0 {
 		writeBufferSize = 0
 	}
-	var r io.Reader = conn
-	if readBufferSize > 0 {
-		r = bufio.NewReaderSize(r, readBufferSize)
-	}
-	var pool *sync.Pool
+	r := bufferedReader(conn, readBufferSize)
+	var writePool *imem.SimpleBufferPool
 	if sharedWriteBuffer {
-		pool = getWriteBufferPool(writeBufferSize)
+		writePool = ioBufferPool(writeBufferSize)
 	}
-	w := newBufWriter(conn, writeBufferSize, pool)
+	w := newBufWriter(conn, writeBufferSize, writePool)
 	f := &framer{
 		writer: w,
 		fr:     http2.NewFramer(w, r),
@@ -578,20 +591,15 @@ func (df *parsedDataFrame) Header() http2.FrameHeader {
 	return df.FrameHeader
 }
 
-func getWriteBufferPool(size int) *sync.Pool {
-	writeBufferMutex.Lock()
-	defer writeBufferMutex.Unlock()
-	pool, ok := writeBufferPoolMap[size]
+func ioBufferPool(size int) *imem.SimpleBufferPool {
+	ioBufferMutex.Lock()
+	defer ioBufferMutex.Unlock()
+	pool, ok := ioBufferPoolMap[size]
 	if ok {
 		return pool
 	}
-	pool = &sync.Pool{
-		New: func() any {
-			b := make([]byte, size)
-			return &b
-		},
-	}
-	writeBufferPoolMap[size] = pool
+	pool = imem.NewDirtySimplePool()
+	ioBufferPoolMap[size] = pool
 	return pool
 }
 

--- a/vendor/google.golang.org/grpc/internal/transport/readyreader/raw_conn_linux.go
+++ b/vendor/google.golang.org/grpc/internal/transport/readyreader/raw_conn_linux.go
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package readyreader
+
+import "syscall"
+
+func isRawConnSupported() bool {
+	return true
+}
+
+// sysRead uses the standard syscall package rather than the modern unix package
+// to avoid triggering the race detector. Because both packages perform sync
+// operations on a local variable to satisfy the race detector, mixing them
+// for read and write syscalls causes data races. We use syscall here to remain
+// consistent with net.Conn implementations in standard library.
+func sysRead(fd uintptr, p []byte) (int, error) {
+	return syscall.Read(int(fd), p)
+}
+
+// wouldBlock checks standard Unix non-blocking errors.
+func wouldBlock(err error) bool {
+	return err == syscall.EAGAIN || err == syscall.EWOULDBLOCK
+}

--- a/vendor/google.golang.org/grpc/internal/transport/readyreader/raw_conn_nonlinux.go
+++ b/vendor/google.golang.org/grpc/internal/transport/readyreader/raw_conn_nonlinux.go
@@ -1,6 +1,8 @@
+//go:build !linux
+
 /*
  *
- * Copyright 2018 gRPC authors.
+ * Copyright 2026 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +18,18 @@
  *
  */
 
-package grpc
+package readyreader
 
-// Version is the current grpc version.
-const Version = "1.81.1"
+func isRawConnSupported() bool {
+	return false
+}
+
+// sysRead is not implemented. Support can be added in the future if necessary.
+func sysRead(uintptr, []byte) (int, error) {
+	panic("RawConn functionality is not implemented for non-unix platforms.")
+}
+
+// wouldBlock is not implemented. Support can be added in the future if necessary.
+func wouldBlock(error) bool {
+	panic("RawConn functionality is not implemented for non-unix platforms.")
+}

--- a/vendor/google.golang.org/grpc/internal/transport/readyreader/ready_reader.go
+++ b/vendor/google.golang.org/grpc/internal/transport/readyreader/ready_reader.go
@@ -1,0 +1,253 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package readyreader provides utilities to perform non-memory-pinning reads.
+package readyreader
+
+import (
+	"io"
+	"net"
+	"syscall"
+
+	"google.golang.org/grpc/mem"
+)
+
+// Reader is an optional interface that can be implemented by [net.Conn]
+// implementations to enable gRPC to perform non-memory-pinning reads.
+type Reader interface {
+	// ReadOnReady waits for data to arrive, fetches a buffer, and performs a
+	// read. When the underlying IO is readable, it allocates a buffer of size
+	// bufSize from the pool and reads up to bufSize bytes into the buffer.
+	//
+	// It returns a pointer to the buffer so it can be returned to the pool
+	// later, the number of bytes read, and an error.
+	//
+	// Callers should always process the n > 0 bytes returned before considering
+	// the error. Doing so correctly handles I/O errors that happen after
+	// reading some bytes, as well as both of the allowed EOF behaviors.
+	ReadOnReady(bufSize int, pool mem.BufferPool) (b *[]byte, n int, err error)
+}
+
+// nonBlockingReader is optimized for non-memory-pinning reads using the RawConn
+// interface.
+type nonBlockingReader struct {
+	raw syscall.RawConn
+	// The following fields are stored as field to avoid heap allocations.
+	state  readState
+	doRead func(fd uintptr) bool
+}
+
+type readState struct {
+	// Request params.
+	bufSize int
+	pool    mem.BufferPool
+
+	// Response params.
+	readError error
+	bytesRead int
+	buf       *[]byte
+}
+
+// NewNonBlocking returns a ReadyReader if the passed reader supports
+// non-memory-pinning reads, else nil.
+func NewNonBlocking(r io.Reader) Reader {
+	if rr, ok := r.(Reader); ok {
+		return rr
+	}
+	if !isRawConnSupported() {
+		return nil
+	}
+	// We restrict the types before asserting syscall.Conn. The credentials
+	// package may return a wrapper that implements syscall.Conn by embedding
+	// both the raw connection and the encrypted connection. If the code
+	// attempts to read directly from the raw syscall.RawConn, it would read
+	// encrypted data.
+	switch r.(type) {
+	case *net.TCPConn, *net.UDPConn, *net.UnixConn, *net.IPConn:
+	default:
+		return nil
+	}
+	sysConn, ok := r.(syscall.Conn)
+	if !ok {
+		return nil
+	}
+	raw, err := sysConn.SyscallConn()
+	if err != nil {
+		return nil
+	}
+	rr := &nonBlockingReader{raw: raw}
+	rr.doRead = func(fd uintptr) bool {
+		s := &rr.state
+
+		s.buf = s.pool.Get(s.bufSize)
+		s.bytesRead, s.readError = sysRead(fd, *s.buf)
+
+		if s.readError != nil {
+			s.pool.Put(s.buf)
+			s.buf = nil
+		}
+		return !wouldBlock(s.readError)
+	}
+	return rr
+}
+
+func (c *nonBlockingReader) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte, int, error) {
+	c.state = readState{
+		pool:    pool,
+		bufSize: bufSize,
+	}
+	err := c.raw.Read(c.doRead)
+
+	buf := c.state.buf
+	n := c.state.bytesRead
+	readErr := c.state.readError
+	c.state = readState{}
+
+	if err != nil {
+		if buf != nil {
+			pool.Put(buf)
+		}
+		return nil, 0, err
+	}
+	if readErr != nil {
+		// buffer is already released in the callback.
+		return nil, 0, readErr
+	}
+	if n == 0 {
+		// syscall.Read doesn't consider a graceful socket closure to be an
+		// error condition, but Go's io.Reader expects an EOF error.
+		pool.Put(buf)
+		return nil, 0, io.EOF
+	}
+	return buf, n, nil
+}
+
+type blockingReader struct {
+	reader io.Reader
+}
+
+func (c *blockingReader) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte, int, error) {
+	buf := pool.Get(bufSize)
+	n, err := c.reader.Read(*buf)
+	if err != nil {
+		pool.Put(buf)
+		return nil, 0, err
+	}
+	return buf, n, nil
+}
+
+// New detects if [syscall.RawConn] is available for non-memory-pinning reads.
+// If [syscall.RawConn] is unavailable, it falls back to using the simpler
+// [io.Reader] interface for reads.
+func New(r io.Reader) Reader {
+	if r := NewNonBlocking(r); r != nil {
+		return r
+	}
+	return &blockingReader{reader: r}
+}
+
+// bufReadyReader implements buffering for a ReadyReader object.
+// A new bufReadyReader is created by calling [NewBuffered].
+type bufReadyReader struct {
+	buf       *[]byte
+	pool      mem.BufferPool
+	bufSize   int
+	rd        Reader // reader provided by the caller
+	r, w      int    // buf read and write positions
+	err       error
+	constPool constBufferPool // stored as a field to avoid heap allocations.
+}
+
+// NewBuffered returns a new [io.Reader] with a buffer of the specified size
+// which is allocated from the provided pool.
+func NewBuffered(rd Reader, size int, pool mem.BufferPool) io.Reader {
+	return &bufReadyReader{
+		rd:      rd,
+		pool:    pool,
+		bufSize: size,
+	}
+}
+
+func (b *bufReadyReader) readErr() error {
+	err := b.err
+	b.err = nil
+	return err
+}
+
+func (b *bufReadyReader) buffered() int { return b.w - b.r }
+
+// Read reads data into p. It returns the number of bytes read into p. The
+// bytes are taken from at most one Read on the underlying [ReadyReader],
+// hence n may be less than len(p). If the underlying [ReadyReader] can return
+// a non-zero count with io.EOF, then this Read method can do so as well; see
+// the [io.Reader] docs.
+func (b *bufReadyReader) Read(p []byte) (n int, err error) {
+	n = len(p)
+	if n == 0 {
+		if b.buffered() > 0 {
+			return 0, nil
+		}
+		return 0, b.readErr()
+	}
+	if b.r == b.w {
+		if b.err != nil {
+			return 0, b.readErr()
+		}
+		if len(p) >= b.bufSize {
+			// Large read, empty buffer.
+			// Read directly into p to avoid copy.
+			b.constPool.buffer = p
+			_, n, b.err = b.rd.ReadOnReady(len(p), &b.constPool)
+			return n, b.readErr()
+		}
+		// One read.
+		b.r = 0
+		b.w = 0
+		b.buf, n, b.err = b.rd.ReadOnReady(b.bufSize, b.pool)
+		if n == 0 {
+			if b.buf != nil {
+				b.pool.Put(b.buf)
+				b.buf = nil
+			}
+			return 0, b.readErr()
+		}
+		b.w += n
+	}
+
+	// copy as much as we can
+	// b.buf must be non-nil since b.r != b.w.
+	buf := *b.buf
+	n = copy(p, buf[b.r:b.w])
+	b.r += n
+	if b.r == b.w {
+		// Consumed entire buffer, release it.
+		b.pool.Put(b.buf)
+		b.buf = nil
+	}
+	return n, nil
+}
+
+type constBufferPool struct {
+	buffer []byte
+}
+
+func (p *constBufferPool) Get(int) *[]byte {
+	return &p.buffer
+}
+
+func (p *constBufferPool) Put(*[]byte) {}

--- a/vendor/google.golang.org/grpc/internal/transport/transport.go
+++ b/vendor/google.golang.org/grpc/internal/transport/transport.go
@@ -31,6 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"
@@ -741,6 +742,22 @@ const (
 	// "too_many_pings".
 	GoAwayTooManyPings GoAwayReason = 2
 )
+
+// GoAwayInfo contains metadata about why a connection was closed.
+type GoAwayInfo struct {
+	// Reason is the parsed reason for an HTTP/2 GOAWAY frame.
+	Reason GoAwayReason
+	// GoAwayCode is the raw HTTP/2 error code received in a GOAWAY frame.
+	GoAwayCode http2.ErrCode
+	// Err is the underlying error that caused the connection to close. It is
+	// populated if the connection was closed due to a socket error or context
+	// cancellation without receiving a GOAWAY frame. If the connection was
+	// closed due to a GOAWAY frame, this field will be nil.
+	Err error
+}
+
+// OnCloseFunc is a callback invoked when a ClientTransport closes.
+type OnCloseFunc func(GoAwayInfo)
 
 // ContextErr converts the error from context package into a status error.
 func ContextErr(err error) error {

--- a/vendor/google.golang.org/grpc/mem/buffer_slice.go
+++ b/vendor/google.golang.org/grpc/mem/buffer_slice.go
@@ -165,7 +165,7 @@ func (r *Reader) Close() error {
 }
 
 func (r *Reader) freeFirstBufferIfEmpty() bool {
-	if len(r.data) == 0 || r.bufferIdx != len(r.data[0].ReadOnlyData()) {
+	if len(r.data) == 0 || r.bufferIdx != r.data[0].Len() {
 		return false
 	}
 

--- a/vendor/google.golang.org/grpc/mem/buffers.go
+++ b/vendor/google.golang.org/grpc/mem/buffers.go
@@ -53,6 +53,10 @@ type Buffer interface {
 	Free()
 	// Len returns the Buffer's size.
 	Len() int
+	// Slice returns a new Buffer that is a view into this buffer's data
+	// from [start:end). The buffer is not modified. Panics if the buffer
+	// has been freed or if start/end are out of bounds.
+	Slice(start, end int) Buffer
 
 	split(n int) (left, right Buffer)
 	read(buf []byte) (int, Buffer)
@@ -180,6 +184,32 @@ func (b *buffer) Len() int {
 	return len(b.ReadOnlyData())
 }
 
+func (b *buffer) Slice(start, end int) Buffer {
+	if b.rootBuf == nil {
+		panic("Cannot slice freed buffer")
+	}
+
+	data := b.data[start:end] // access the data to check slice bounds
+
+	if len(data) == 0 {
+		return emptyBuffer{}
+	}
+	if len(data) == len(b.data) {
+		b.Ref()
+		return b
+	}
+	// We are creating a new reference (view) to a portion of the root buffer's
+	// data. Therefore, we must increment the reference count of the root buffer
+	// to ensure the underlying data is not freed while this view is still in
+	// use.
+	b.rootBuf.Ref()
+	s := newBuffer()
+	s.data = data
+	s.rootBuf = b.rootBuf
+	s.refs.Store(1)
+	return s
+}
+
 func (b *buffer) split(n int) (Buffer, Buffer) {
 	if b.rootBuf == nil || b.rootBuf.refs.Add(1) <= 1 {
 		panic("Cannot split freed buffer")
@@ -240,6 +270,13 @@ func (e emptyBuffer) Len() int {
 	return 0
 }
 
+func (e emptyBuffer) Slice(start, end int) Buffer {
+	if start != 0 || end != 0 {
+		panic(fmt.Sprintf("slice bounds out of range [%d:%d] with length 0", start, end))
+	}
+	return e
+}
+
 func (e emptyBuffer) split(int) (left, right Buffer) {
 	return e, e
 }
@@ -263,6 +300,9 @@ func (s SliceBuffer) Free() {}
 
 // Len is a noop implementation of Len.
 func (s SliceBuffer) Len() int { return len(s) }
+
+// Slice returns a new SliceBuffer that is a view into the receiver from [start:end).
+func (s SliceBuffer) Slice(start, end int) Buffer { return s[start:end] }
 
 func (s SliceBuffer) split(n int) (left, right Buffer) {
 	return s[:n], s[n:]

--- a/vendor/google.golang.org/grpc/stream.go
+++ b/vendor/google.golang.org/grpc/stream.go
@@ -21,6 +21,7 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	rand "math/rand/v2"
@@ -749,7 +750,7 @@ func (a *csAttempt) shouldRetry(err error) (bool, error) {
 		return false, err
 	}
 	if cs.numRetries+1 >= rp.MaxAttempts {
-		return false, err
+		return false, fmt.Errorf("max retries exhausted: failed after %d attempts: %w", cs.numRetries+1, err)
 	}
 
 	var dur time.Duration

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1056,7 +1056,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.18
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift-pipelines/pipelines-as-code v0.46.0
+# github.com/openshift-pipelines/pipelines-as-code v0.47.0
 ## explicit; go 1.25.7
 github.com/openshift-pipelines/pipelines-as-code/pkg/cli
 github.com/openshift-pipelines/pipelines-as-code/pkg/configutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -654,7 +654,7 @@ github.com/golang-jwt/jwt/v4
 # github.com/golang/snappy v0.0.4
 ## explicit
 github.com/golang/snappy
-# github.com/google/cel-go v0.28.0
+# github.com/google/cel-go v0.28.1
 ## explicit; go 1.23.0
 github.com/google/cel-go/cel
 github.com/google/cel-go/checker
@@ -1542,8 +1542,8 @@ github.com/tektoncd/plumbing/scripts
 ## explicit; go 1.25.7
 github.com/tektoncd/pruner/pkg/config
 github.com/tektoncd/pruner/pkg/metrics
-# github.com/tektoncd/triggers v0.35.0
-## explicit; go 1.24.0
+# github.com/tektoncd/triggers v0.36.0
+## explicit; go 1.25.7
 github.com/tektoncd/triggers/pkg/apis/config
 github.com/tektoncd/triggers/pkg/apis/triggers
 github.com/tektoncd/triggers/pkg/apis/triggers/contexts
@@ -1926,8 +1926,8 @@ google.golang.org/genproto/googleapis/api/httpbody
 ## explicit; go 1.25.0
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.80.0
-## explicit; go 1.24.0
+# google.golang.org/grpc v1.81.1
+## explicit; go 1.25.0
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -1982,6 +1982,7 @@ google.golang.org/grpc/internal/status
 google.golang.org/grpc/internal/syscall
 google.golang.org/grpc/internal/transport
 google.golang.org/grpc/internal/transport/networktype
+google.golang.org/grpc/internal/transport/readyreader
 google.golang.org/grpc/keepalive
 google.golang.org/grpc/mem
 google.golang.org/grpc/metadata


### PR DESCRIPTION
## Problem

When uninstalling via the Console UI, \`TektonConfig\` finalization calls
\`rbac.cleanUp()\` which updates user namespaces to strip the
\`openshift-pipelines.tekton.dev/namespace-reconcile-version\` label.
The \`namespace.operator.tekton.dev\` ValidatingWebhookConfiguration
intercepts every namespace update and calls the
\`tekton-operator-proxy-webhook\` service in \`openshift-pipelines\`.

When the UI removes \`openshift-pipelines\` before finalization completes,
the VWH still exists (GC lag) but the backend service is already gone:

\`\`\`
Failed to finalize platform resources failed to update namespace default:
failed calling webhook "namespace.operator.tekton.dev":
service "tekton-operator-proxy-webhook" not found
\`\`\`

Result: finalization stuck → Subscription/CSV never deleted → operator pod,
deployments, CRDs and ClusterRoles remain in \`openshift-operators\`.

## Root cause

The VWH/MWH are owned by the \`openshift-pipelines\` Namespace (SRVKP-8901)
and are GC'd when it is deleted — but there is a window where the namespace
is **Terminating** (services gone) while the webhook configs still exist.
\`cleanUp()\` namespace updates fail during that window.

## Fix

Delete \`namespace.operator.tekton.dev\` (VWH) and \`proxy.operator.tekton.dev\`
(MWH) at the **start of \`openshiftExtension.Finalize\`**, before
\`rbac.cleanUp()\` runs. \`NotFound\` is ignored (already GC'd). The
ownerRef-based GC from SRVKP-8901 is kept as the normal cleanup path.

Also propagate errors from \`extension.Finalize\` in \`FinalizeKind\` so the
finalizer retries on failure instead of silently continuing.

## Testing

Verified on OpenShift 4.20 (AWS) — installed OSP 1.22.2 via OperatorHub,
patched operator image with this fix, triggered UI uninstall. Confirmed:

- No \`service "tekton-operator-proxy-webhook" not found\` errors in logs ✅
- VWH \`namespace.operator.tekton.dev\` removed ✅
- MWH \`proxy.operator.tekton.dev\` removed ✅
- Subscription, CSV, operator deployments all removed ✅
- \`openshift-pipelines\` namespace removed ✅
- CRDs remain (expected — OLM does not delete CRDs on uninstall)

Unit tests: \`TestRemoveOperatorAdmissionWebhooks\` (delete both, already-absent, delete-failure).

Fixes: SRVKP-12010

Made with [Cursor](https://cursor.com)